### PR TITLE
Update commons-codec to reject decoding any impossible string for Base32 and Base64.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Commons Codec
-Copyright 2002-2017 The Apache Software Foundation
+Copyright 2002-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/src/main/java/org/apache/commons/codec/BinaryDecoder.java
+++ b/src/main/java/org/apache/commons/codec/BinaryDecoder.java
@@ -20,7 +20,6 @@ package org.apache.commons.codec;
 /**
  * Defines common decoding methods for byte array decoders.
  *
- * @version $Id$
  */
 public interface BinaryDecoder extends Decoder {
 

--- a/src/main/java/org/apache/commons/codec/BinaryEncoder.java
+++ b/src/main/java/org/apache/commons/codec/BinaryEncoder.java
@@ -20,7 +20,6 @@ package org.apache.commons.codec;
 /**
  * Defines common encoding methods for byte array encoders.
  *
- * @version $Id$
  */
 public interface BinaryEncoder extends Encoder {
 

--- a/src/main/java/org/apache/commons/codec/CharEncoding.java
+++ b/src/main/java/org/apache/commons/codec/CharEncoding.java
@@ -53,7 +53,6 @@ package org.apache.commons.codec;
  *
  * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
  * @since 1.4
- * @version $Id$
  */
 public class CharEncoding {
     /**

--- a/src/main/java/org/apache/commons/codec/CharEncoding.java
+++ b/src/main/java/org/apache/commons/codec/CharEncoding.java
@@ -29,19 +29,19 @@ package org.apache.commons.codec;
  * </p>
  *
  * <ul>
- * <li><code>US-ASCII</code><br>
- * Seven-bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode character set.</li>
- * <li><code>ISO-8859-1</code><br>
- * ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.</li>
- * <li><code>UTF-8</code><br>
- * Eight-bit Unicode Transformation Format.</li>
- * <li><code>UTF-16BE</code><br>
- * Sixteen-bit Unicode Transformation Format, big-endian byte order.</li>
- * <li><code>UTF-16LE</code><br>
- * Sixteen-bit Unicode Transformation Format, little-endian byte order.</li>
- * <li><code>UTF-16</code><br>
+ * <li><code>US-ASCII</code><p>
+ * Seven-bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode character set.</p></li>
+ * <li><code>ISO-8859-1</code><p>
+ * ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.</p></li>
+ * <li><code>UTF-8</code><p>
+ * Eight-bit Unicode Transformation Format.</p></li>
+ * <li><code>UTF-16BE</code><p>
+ * Sixteen-bit Unicode Transformation Format, big-endian byte order.</p></li>
+ * <li><code>UTF-16LE</code><p>
+ * Sixteen-bit Unicode Transformation Format, little-endian byte order.</p></li>
+ * <li><code>UTF-16</code><p>
  * Sixteen-bit Unicode Transformation Format, byte order specified by a mandatory initial byte-order mark (either order
- * accepted on input, big-endian used on output.)</li>
+ * accepted on input, big-endian used on output.)</p></li>
  * </ul>
  *
  * This perhaps would best belong in the [lang] project. Even if a similar interface is defined in [lang], it is not
@@ -55,10 +55,12 @@ package org.apache.commons.codec;
  * @since 1.4
  */
 public class CharEncoding {
+    
     /**
      * CharEncodingISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.
      * <p>
      * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
      *
      * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
      */
@@ -68,6 +70,7 @@ public class CharEncoding {
      * Seven-bit ASCII, also known as ISO646-US, also known as the Basic Latin block of the Unicode character set.
      * <p>
      * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
      *
      * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
      */
@@ -78,6 +81,7 @@ public class CharEncoding {
      * (either order accepted on input, big-endian used on output)
      * <p>
      * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
      *
      * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
      */
@@ -87,6 +91,7 @@ public class CharEncoding {
      * Sixteen-bit Unicode Transformation Format, big-endian byte order.
      * <p>
      * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
      *
      * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
      */
@@ -96,6 +101,7 @@ public class CharEncoding {
      * Sixteen-bit Unicode Transformation Format, little-endian byte order.
      * <p>
      * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
      *
      * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
      */
@@ -105,6 +111,7 @@ public class CharEncoding {
      * Eight-bit Unicode Transformation Format.
      * <p>
      * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
      *
      * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
      */

--- a/src/main/java/org/apache/commons/codec/Charsets.java
+++ b/src/main/java/org/apache/commons/codec/Charsets.java
@@ -30,19 +30,19 @@ import java.nio.charset.Charset;
  * </p>
  *
  * <ul>
- * <li><code>US-ASCII</code><br>
- * Seven-bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode character set.</li>
- * <li><code>ISO-8859-1</code><br>
- * ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.</li>
- * <li><code>UTF-8</code><br>
- * Eight-bit Unicode Transformation Format.</li>
- * <li><code>UTF-16BE</code><br>
- * Sixteen-bit Unicode Transformation Format, big-endian byte order.</li>
- * <li><code>UTF-16LE</code><br>
- * Sixteen-bit Unicode Transformation Format, little-endian byte order.</li>
- * <li><code>UTF-16</code><br>
+ * <li><code>US-ASCII</code><p>
+ * Seven-bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode character set.</p></li>
+ * <li><code>ISO-8859-1</code><p>
+ * ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.</p></li>
+ * <li><code>UTF-8</code><p>
+ * Eight-bit Unicode Transformation Format.</p></li>
+ * <li><code>UTF-16BE</code><p>
+ * Sixteen-bit Unicode Transformation Format, big-endian byte order.</p></li>
+ * <li><code>UTF-16LE</code><p>
+ * Sixteen-bit Unicode Transformation Format, little-endian byte order.</p></li>
+ * <li><code>UTF-16</code><p>
  * Sixteen-bit Unicode Transformation Format, byte order specified by a mandatory initial byte-order mark (either order
- * accepted on input, big-endian used on output.)</li>
+ * accepted on input, big-endian used on output.)</p></li>
  * </ul>
  *
  * This perhaps would best belong in the Commons Lang project. Even if a similar class is defined in Commons Lang, it is

--- a/src/main/java/org/apache/commons/codec/Charsets.java
+++ b/src/main/java/org/apache/commons/codec/Charsets.java
@@ -54,7 +54,6 @@ import java.nio.charset.Charset;
  *
  * @see <a href="http://docs.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
  * @since 1.7
- * @version $Id: CharEncoding.java 1173287 2011-09-20 18:16:19Z ggregory $
  */
 public class Charsets {
 

--- a/src/main/java/org/apache/commons/codec/Decoder.java
+++ b/src/main/java/org/apache/commons/codec/Decoder.java
@@ -25,7 +25,6 @@ package org.apache.commons.codec;
  * <p>
  * One of the two interfaces at the center of the codec package.
  *
- * @version $Id$
  */
 public interface Decoder {
 

--- a/src/main/java/org/apache/commons/codec/DecoderException.java
+++ b/src/main/java/org/apache/commons/codec/DecoderException.java
@@ -21,7 +21,6 @@ package org.apache.commons.codec;
  * Thrown when there is a failure condition during the decoding process. This exception is thrown when a {@link Decoder}
  * encounters a decoding specific exception such as invalid data, or characters outside of the expected range.
  *
- * @version $Id$
  */
 public class DecoderException extends Exception {
 

--- a/src/main/java/org/apache/commons/codec/Encoder.java
+++ b/src/main/java/org/apache/commons/codec/Encoder.java
@@ -24,7 +24,6 @@ package org.apache.commons.codec;
  * common generic interface which allows a user to pass a generic Object to any Encoder implementation
  * in the codec package.
  *
- * @version $Id$
  */
 public interface Encoder {
 

--- a/src/main/java/org/apache/commons/codec/EncoderException.java
+++ b/src/main/java/org/apache/commons/codec/EncoderException.java
@@ -22,7 +22,6 @@ package org.apache.commons.codec;
  * {@link Encoder} encounters a encoding specific exception such as invalid data, inability to calculate a checksum,
  * characters outside of the expected range.
  *
- * @version $Id$
  */
 public class EncoderException extends Exception {
 

--- a/src/main/java/org/apache/commons/codec/StringDecoder.java
+++ b/src/main/java/org/apache/commons/codec/StringDecoder.java
@@ -20,7 +20,6 @@ package org.apache.commons.codec;
 /**
  * Defines common decoding methods for String decoders.
  *
- * @version $Id$
  */
 public interface StringDecoder extends Decoder {
 

--- a/src/main/java/org/apache/commons/codec/StringEncoder.java
+++ b/src/main/java/org/apache/commons/codec/StringEncoder.java
@@ -20,7 +20,6 @@ package org.apache.commons.codec;
 /**
  * Defines common encoding methods for String encoders.
  *
- * @version $Id$
  */
 public interface StringEncoder extends Encoder {
 

--- a/src/main/java/org/apache/commons/codec/StringEncoderComparator.java
+++ b/src/main/java/org/apache/commons/codec/StringEncoderComparator.java
@@ -26,7 +26,6 @@ import java.util.Comparator;
  *
  * <p>This class is immutable and thread-safe.</p>
  *
- * @version $Id$
  */
 @SuppressWarnings("rawtypes")
 // TODO ought to implement Comparator<String> but that's not possible whilst maintaining binary compatibility.

--- a/src/main/java/org/apache/commons/codec/binary/Base32.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base32.java
@@ -39,7 +39,6 @@ package org.apache.commons.codec.binary;
  * @see <a href="http://www.ietf.org/rfc/rfc4648.txt">RFC 4648</a>
  *
  * @since 1.5
- * @version $Id$
  */
 public class Base32 extends BaseNCodec {
 

--- a/src/main/java/org/apache/commons/codec/binary/Base32.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base32.java
@@ -382,30 +382,36 @@ public class Base32 extends BaseNCodec {
             //  we ignore partial bytes, i.e. only multiples of 8 count
             switch (context.modulus) {
                 case 2 : // 10 bits, drop 2 and output one byte
-                    buffer[context.pos++] = (byte) (dropBits(2, context) & MASK_8BITS);
+                    validateCharacter(2, context);
+                    buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 2) & MASK_8BITS);
                     break;
                 case 3 : // 15 bits, drop 7 and output 1 byte
-                    buffer[context.pos++] = (byte) (dropBits(7, context) & MASK_8BITS);
+                    validateCharacter(7, context);
+                    buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 7) & MASK_8BITS);
                     break;
                 case 4 : // 20 bits = 2*8 + 4
-                    context.lbitWorkArea = dropBits(4, context); // drop 4 bits
+                    validateCharacter(4, context);
+                    context.lbitWorkArea = context.lbitWorkArea >> 4; // drop 4 bits
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea) & MASK_8BITS);
                     break;
                 case 5 : // 25bits = 3*8 + 1
-                    context.lbitWorkArea = dropBits(1, context);
+                    validateCharacter(1, context);
+                    context.lbitWorkArea = context.lbitWorkArea >> 1;
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 16) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea) & MASK_8BITS);
                     break;
                 case 6 : // 30bits = 3*8 + 6
-                    context.lbitWorkArea = dropBits(6, context);
+                    validateCharacter(6, context);
+                    context.lbitWorkArea = context.lbitWorkArea >> 6;
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 16) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea) & MASK_8BITS);
                     break;
                 case 7 : // 35 = 4*8 +3
-                    context.lbitWorkArea = dropBits(3, context);
+                    validateCharacter(3, context);
+                    context.lbitWorkArea = context.lbitWorkArea >> 3;
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 24) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 16) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 8) & MASK_8BITS);
@@ -544,23 +550,18 @@ public class Base32 extends BaseNCodec {
 
     /**
      * <p>
-     * Drops the specified number of least significant bits from the
-     * {@link #bitWorkArea}.
+     * Validates whether the character is possible in the context of the set of possible base 32 values.
      * </p>
-     *
-     * @param numBitsToDrop number of least significant bits to drop
-     *
-     * @return the value of {@link #bitWorkArea} after dropping the specified number
-     *         of least significant bits
-     *
-     * @throws IllegalArgumentException if the bits being dropped contain any
-     *                                  non-zero value
+     * 
+     * @param numBits number of least significant bits to check
+     * @param context the context to be used
+     * 
+     * @throws IllegalArgumentException if the bits being checked contain any non-zero value
      */
-    private long dropBits(int numBitsToDrop, Context context) {
-        if ((context.lbitWorkArea & numBitsToDrop) != 0) {
-            throw new IllegalArgumentException(
-                "Last encoded character (before the paddings if any) is a valid base 32 alphabet but not a possible value");
-            }
-            return context.lbitWorkArea >> numBitsToDrop;
-    }
+	private void validateCharacter(int numBits, Context context) {
+		if ((context.lbitWorkArea & numBits) != 0) {
+			throw new IllegalArgumentException(
+					"Last encoded character (before the paddings if any) is a valid base 32 alphabet but not a possible value");
+		}
+	}
 }

--- a/src/main/java/org/apache/commons/codec/binary/Base32.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base32.java
@@ -558,10 +558,10 @@ public class Base32 extends BaseNCodec {
      * 
      * @throws IllegalArgumentException if the bits being checked contain any non-zero value
      */
-	private void validateCharacter(int numBits, Context context) {
-		if ((context.lbitWorkArea & numBits) != 0) {
-			throw new IllegalArgumentException(
-					"Last encoded character (before the paddings if any) is a valid base 32 alphabet but not a possible value");
-		}
-	}
+    private void validateCharacter(int numBits, Context context) {
+        if ((context.lbitWorkArea & numBits) != 0) {
+            throw new IllegalArgumentException(
+                "Last encoded character (before the paddings if any) is a valid base 32 alphabet but not a possible value");
+        }
+    }
 }

--- a/src/main/java/org/apache/commons/codec/binary/Base32.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base32.java
@@ -333,7 +333,7 @@ public class Base32 extends BaseNCodec {
      * @param inPos
      *            Position to start reading data from.
      * @param inAvail
-     *            Amount of bytes available from input for encoding.
+     *            Amount of bytes available from input for decoding.
      * @param context the context to be used
      *
      * Output is written to {@link Context#buffer} as 8-bit octets, using {@link Context#pos} as the buffer position
@@ -382,30 +382,30 @@ public class Base32 extends BaseNCodec {
             //  we ignore partial bytes, i.e. only multiples of 8 count
             switch (context.modulus) {
                 case 2 : // 10 bits, drop 2 and output one byte
-                    buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 2) & MASK_8BITS);
+                    buffer[context.pos++] = (byte) (dropBits(2, context) & MASK_8BITS);
                     break;
                 case 3 : // 15 bits, drop 7 and output 1 byte
-                    buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 7) & MASK_8BITS);
+                    buffer[context.pos++] = (byte) (dropBits(7, context) & MASK_8BITS);
                     break;
                 case 4 : // 20 bits = 2*8 + 4
-                    context.lbitWorkArea = context.lbitWorkArea >> 4; // drop 4 bits
+                    context.lbitWorkArea = dropBits(4, context); // drop 4 bits
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea) & MASK_8BITS);
                     break;
                 case 5 : // 25bits = 3*8 + 1
-                    context.lbitWorkArea = context.lbitWorkArea >> 1;
+                    context.lbitWorkArea = dropBits(1, context);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 16) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea) & MASK_8BITS);
                     break;
                 case 6 : // 30bits = 3*8 + 6
-                    context.lbitWorkArea = context.lbitWorkArea >> 6;
+                    context.lbitWorkArea = dropBits(6, context);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 16) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea) & MASK_8BITS);
                     break;
                 case 7 : // 35 = 4*8 +3
-                    context.lbitWorkArea = context.lbitWorkArea >> 3;
+                    context.lbitWorkArea = dropBits(3, context);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 24) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 16) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.lbitWorkArea >> 8) & MASK_8BITS);
@@ -540,5 +540,27 @@ public class Base32 extends BaseNCodec {
     @Override
     public boolean isInAlphabet(final byte octet) {
         return octet >= 0 && octet < decodeTable.length && decodeTable[octet] != -1;
+    }
+
+    /**
+     * <p>
+     * Drops the specified number of least significant bits from the
+     * {@link #bitWorkArea}.
+     * </p>
+     *
+     * @param numBitsToDrop number of least significant bits to drop
+     *
+     * @return the value of {@link #bitWorkArea} after dropping the specified number
+     *         of least significant bits
+     *
+     * @throws IllegalArgumentException if the bits being dropped contain any
+     *                                  non-zero value
+     */
+    private long dropBits(int numBitsToDrop, Context context) {
+        if ((context.lbitWorkArea & numBitsToDrop) != 0) {
+            throw new IllegalArgumentException(
+                "Last encoded character (before the paddings if any) is a valid base 32 alphabet but not a possible value");
+            }
+            return context.lbitWorkArea >> numBitsToDrop;
     }
 }

--- a/src/main/java/org/apache/commons/codec/binary/Base32InputStream.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base32InputStream.java
@@ -32,7 +32,6 @@ import java.io.InputStream;
  * character encodings which are compatible with the lower 127 ASCII chart (ISO-8859-1, Windows-1252, UTF-8, etc).
  * </p>
  *
- * @version $Id$
  * @see <a href="http://www.ietf.org/rfc/rfc4648.txt">RFC 4648</a>
  * @since 1.5
  */

--- a/src/main/java/org/apache/commons/codec/binary/Base32OutputStream.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base32OutputStream.java
@@ -36,7 +36,6 @@ import java.io.OutputStream;
  * final padding will be omitted and the resulting data will be incomplete/inconsistent.
  * </p>
  *
- * @version $Id$
  * @see <a href="http://www.ietf.org/rfc/rfc4648.txt">RFC 4648</a>
  * @since 1.5
  */

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -49,7 +49,6 @@ import java.math.BigInteger;
  *
  * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
  * @since 1.0
- * @version $Id$
  */
 public class Base64 extends BaseNCodec {
 

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -470,11 +470,13 @@ public class Base64 extends BaseNCodec {
                     // TODO not currently tested; perhaps it is impossible?
                     break;
                 case 2 : // 12 bits = 8 + 4
-                    context.ibitWorkArea = (int) dropBits(4, context); // dump the extra 4 bits
+                    validateCharacter(4, context);
+                    context.ibitWorkArea = context.ibitWorkArea >> 4; // dump the extra 4 bits
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
                     break;
                 case 3 : // 18 bits = 8 + 8 + 2
-                    context.ibitWorkArea = (int) dropBits(2, context); // dump 2 bits
+                    validateCharacter(2, context);
+                    context.ibitWorkArea = context.ibitWorkArea >> 2; // dump 2 bits
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
                     break;
@@ -784,23 +786,19 @@ public class Base64 extends BaseNCodec {
 
     /**
      * <p>
-     * Drops the specified number of least significant bits from the
-     * {@link #bitWorkArea}.
+     * Validates whether the character is possible in the context of the set of possible base 64 values.
      * </p>
-     *
-     * @param numBitsToDrop number of least significant bits to drop
-     *
-     * @return the value of {@link #bitWorkArea} after dropping the specified number
-     *         of least significant bits
-     *
-     * @throws IllegalArgumentException if the bits being dropped contain any
-     *                                  non-zero value
+     * 
+     * @param numBits number of least significant bits to check
+     * @param context the context to be used
+     * 
+     * @throws IllegalArgumentException if the bits being checked contain any non-zero value
      */
-    private long dropBits(int numBitsToDrop, Context context) {
-        if ((context.ibitWorkArea & numBitsToDrop) != 0) {
-            throw new IllegalArgumentException(
-                "Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value");
-        }
-        return context.ibitWorkArea >> numBitsToDrop;
-    }
+	private long validateCharacter(int numBitsToDrop, Context context) {
+		if ((context.ibitWorkArea & numBitsToDrop) != 0) {
+			throw new IllegalArgumentException(
+					"Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value");
+		}
+		return context.ibitWorkArea >> numBitsToDrop;
+	}
 }

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -422,7 +422,7 @@ public class Base64 extends BaseNCodec {
      * @param inPos
      *            Position to start reading data from.
      * @param inAvail
-     *            Amount of bytes available from input for encoding.
+     *            Amount of bytes available from input for decoding.
      * @param context
      *            the context to be used
      */
@@ -470,11 +470,11 @@ public class Base64 extends BaseNCodec {
                     // TODO not currently tested; perhaps it is impossible?
                     break;
                 case 2 : // 12 bits = 8 + 4
-                    context.ibitWorkArea = context.ibitWorkArea >> 4; // dump the extra 4 bits
+                    context.ibitWorkArea = (int) dropBits(4, context); // dump the extra 4 bits
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
                     break;
                 case 3 : // 18 bits = 8 + 8 + 2
-                    context.ibitWorkArea = context.ibitWorkArea >> 2; // dump 2 bits
+                    context.ibitWorkArea = (int) dropBits(2, context); // dump 2 bits
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
                     break;
@@ -782,4 +782,25 @@ public class Base64 extends BaseNCodec {
         return octet >= 0 && octet < decodeTable.length && decodeTable[octet] != -1;
     }
 
+    /**
+     * <p>
+     * Drops the specified number of least significant bits from the
+     * {@link #bitWorkArea}.
+     * </p>
+     *
+     * @param numBitsToDrop number of least significant bits to drop
+     *
+     * @return the value of {@link #bitWorkArea} after dropping the specified number
+     *         of least significant bits
+     *
+     * @throws IllegalArgumentException if the bits being dropped contain any
+     *                                  non-zero value
+     */
+    private long dropBits(int numBitsToDrop, Context context) {
+        if ((context.ibitWorkArea & numBitsToDrop) != 0) {
+            throw new IllegalArgumentException(
+                "Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value");
+        }
+        return context.ibitWorkArea >> numBitsToDrop;
+    }
 }

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -794,11 +794,11 @@ public class Base64 extends BaseNCodec {
      * 
      * @throws IllegalArgumentException if the bits being checked contain any non-zero value
      */
-	private long validateCharacter(int numBitsToDrop, Context context) {
-		if ((context.ibitWorkArea & numBitsToDrop) != 0) {
-			throw new IllegalArgumentException(
-					"Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value");
-		}
-		return context.ibitWorkArea >> numBitsToDrop;
-	}
+    private long validateCharacter(int numBitsToDrop, Context context) {
+        if ((context.ibitWorkArea & numBitsToDrop) != 0) {
+        throw new IllegalArgumentException(
+            "Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value");
+        }
+        return context.ibitWorkArea >> numBitsToDrop;
+    }
 }

--- a/src/main/java/org/apache/commons/codec/binary/Base64InputStream.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64InputStream.java
@@ -36,7 +36,6 @@ import java.io.InputStream;
  * character encodings which are compatible with the lower 127 ASCII chart (ISO-8859-1, Windows-1252, UTF-8, etc).
  * </p>
  *
- * @version $Id$
  * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
  * @since 1.4
  */

--- a/src/main/java/org/apache/commons/codec/binary/Base64OutputStream.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64OutputStream.java
@@ -40,7 +40,6 @@ import java.io.OutputStream;
  * final padding will be omitted and the resulting data will be incomplete/inconsistent.
  * </p>
  *
- * @version $Id$
  * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
  * @since 1.4
  */

--- a/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
+++ b/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
@@ -31,7 +31,6 @@ import org.apache.commons.codec.EncoderException;
  * This class is thread-safe.
  * </p>
  *
- * @version $Id$
  */
 public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
 

--- a/src/main/java/org/apache/commons/codec/binary/BaseNCodecInputStream.java
+++ b/src/main/java/org/apache/commons/codec/binary/BaseNCodecInputStream.java
@@ -29,7 +29,6 @@ import org.apache.commons.codec.binary.BaseNCodec.Context;
  * Abstract superclass for Base-N input streams.
  *
  * @since 1.5
- * @version $Id$
  */
 public class BaseNCodecInputStream extends FilterInputStream {
 

--- a/src/main/java/org/apache/commons/codec/binary/BaseNCodecOutputStream.java
+++ b/src/main/java/org/apache/commons/codec/binary/BaseNCodecOutputStream.java
@@ -35,7 +35,6 @@ import org.apache.commons.codec.binary.BaseNCodec.Context;
  * </p>
  *
  * @since 1.5
- * @version $Id$
  */
 public class BaseNCodecOutputStream extends FilterOutputStream {
 

--- a/src/main/java/org/apache/commons/codec/binary/BinaryCodec.java
+++ b/src/main/java/org/apache/commons/codec/binary/BinaryCodec.java
@@ -31,7 +31,6 @@ import org.apache.commons.codec.EncoderException;
  * TODO: also might be good to generate boolean[] from byte[] et cetera.
  *
  * @since 1.3
- * @version $Id$
  */
 public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
     /*

--- a/src/main/java/org/apache/commons/codec/binary/Hex.java
+++ b/src/main/java/org/apache/commons/codec/binary/Hex.java
@@ -34,7 +34,6 @@ import org.apache.commons.codec.EncoderException;
  * This class is thread-safe.
  *
  * @since 1.1
- * @version $Id$
  */
 public class Hex implements BinaryEncoder, BinaryDecoder {
 

--- a/src/main/java/org/apache/commons/codec/binary/StringUtils.java
+++ b/src/main/java/org/apache/commons/codec/binary/StringUtils.java
@@ -33,7 +33,6 @@ import org.apache.commons.codec.Charsets;
  *
  * @see CharEncoding
  * @see <a href="http://download.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
- * @version $Id$
  * @since 1.4
  */
 public class StringUtils {

--- a/src/main/java/org/apache/commons/codec/digest/B64.java
+++ b/src/main/java/org/apache/commons/codec/digest/B64.java
@@ -28,7 +28,6 @@ import java.util.Random;
  * This class is immutable and thread-safe.
  * </p>
  *
- * @version $Id$
  * @since 1.7
  */
 class B64 {

--- a/src/main/java/org/apache/commons/codec/digest/Crypt.java
+++ b/src/main/java/org/apache/commons/codec/digest/Crypt.java
@@ -28,7 +28,6 @@ import org.apache.commons.codec.Charsets;
  * <p>
  * This class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.7
  */
 public class Crypt {

--- a/src/main/java/org/apache/commons/codec/digest/DigestUtils.java
+++ b/src/main/java/org/apache/commons/codec/digest/DigestUtils.java
@@ -48,7 +48,6 @@ import org.apache.commons.codec.binary.StringUtils;
  * String hdigest = new DigestUtils(SHA_224).digestAsHex(new File("pom.xml"));
  * </pre>
  * @see MessageDigestAlgorithms
- * @version $Id$
  */
 public class DigestUtils {
 

--- a/src/main/java/org/apache/commons/codec/digest/HmacAlgorithms.java
+++ b/src/main/java/org/apache/commons/codec/digest/HmacAlgorithms.java
@@ -35,7 +35,6 @@ package org.apache.commons.codec.digest;
  *      "http://docs.oracle.com/javase/9/security/oracleproviders.htm#JSSEC-GUID-A47B1249-593C-4C38-A0D0-68FA7681E0A7">
  *      Java 9 Cryptography Architecture Sun Providers Documentation</a>
  * @since 1.10
- * @version $Id$
  */
 public enum HmacAlgorithms {
 

--- a/src/main/java/org/apache/commons/codec/digest/HmacUtils.java
+++ b/src/main/java/org/apache/commons/codec/digest/HmacUtils.java
@@ -52,7 +52,6 @@ import org.apache.commons.codec.binary.StringUtils;
  * String hexNot = hm1.hmacHex(new File("NOTICE.txt"));
  * </pre>
  * @since 1.10
- * @version $Id$
  */
 public final class HmacUtils {
 

--- a/src/main/java/org/apache/commons/codec/digest/Md5Crypt.java
+++ b/src/main/java/org/apache/commons/codec/digest/Md5Crypt.java
@@ -31,19 +31,23 @@ import org.apache.commons.codec.Charsets;
  * <p>
  * Based on the public domain ("beer-ware") C implementation from Poul-Henning Kamp which was found at: <a
  * href="http://www.freebsd.org/cgi/cvsweb.cgi/src/lib/libcrypt/crypt-md5.c?rev=1.1;content-type=text%2Fplain">
- * crypt-md5.c @ freebsd.org</a><br>
+ * crypt-md5.c @ freebsd.org</a>
+ * </p>
  * <p>
  * Source:
- *
+ * </p>
  * <pre>
  * $FreeBSD: src/lib/libcrypt/crypt-md5.c,v 1.1 1999/01/21 13:50:09 brandon Exp $
  * </pre>
  * <p>
  * Conversion to Kotlin and from there to Java in 2012.
+ * </p>
  * <p>
  * The C style comments are from the original C code, the ones with "//" from the port.
+ * </p>
  * <p>
  * This class is immutable and thread-safe.
+ * </p>
  *
  * @since 1.7
  */

--- a/src/main/java/org/apache/commons/codec/digest/Md5Crypt.java
+++ b/src/main/java/org/apache/commons/codec/digest/Md5Crypt.java
@@ -45,7 +45,6 @@ import org.apache.commons.codec.Charsets;
  * <p>
  * This class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.7
  */
 public class Md5Crypt {

--- a/src/main/java/org/apache/commons/codec/digest/MessageDigestAlgorithms.java
+++ b/src/main/java/org/apache/commons/codec/digest/MessageDigestAlgorithms.java
@@ -44,7 +44,6 @@ import java.security.MessageDigest;
  * @see <a href="http://dx.doi.org/10.6028/NIST.FIPS.180-4">FIPS PUB 180-4</a>
  * @see <a href="http://dx.doi.org/10.6028/NIST.FIPS.202">FIPS PUB 202</a>
  * @since 1.7
- * @version $Id$
  */
 public class MessageDigestAlgorithms {
 

--- a/src/main/java/org/apache/commons/codec/digest/Sha2Crypt.java
+++ b/src/main/java/org/apache/commons/codec/digest/Sha2Crypt.java
@@ -38,7 +38,6 @@ import org.apache.commons.codec.Charsets;
  * <p>
  * This class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.7
  */
 public class Sha2Crypt {

--- a/src/main/java/org/apache/commons/codec/digest/UnixCrypt.java
+++ b/src/main/java/org/apache/commons/codec/digest/UnixCrypt.java
@@ -35,7 +35,6 @@ import org.apache.commons.codec.Charsets;
  * <p>
  * This class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.7
  */
 public class UnixCrypt {

--- a/src/main/java/org/apache/commons/codec/language/AbstractCaverphone.java
+++ b/src/main/java/org/apache/commons/codec/language/AbstractCaverphone.java
@@ -28,7 +28,6 @@ import org.apache.commons.codec.StringEncoder;
  *
  * <p>This class is immutable and thread-safe.</p>
  *
- * @version $Id: Caverphone.java 1075947 2011-03-01 17:56:14Z ggregory $
  * @see <a href="http://en.wikipedia.org/wiki/Caverphone">Wikipedia - Caverphone</a>
  * @since 1.5
  */

--- a/src/main/java/org/apache/commons/codec/language/Caverphone.java
+++ b/src/main/java/org/apache/commons/codec/language/Caverphone.java
@@ -26,7 +26,6 @@ import org.apache.commons.codec.StringEncoder;
  * This is an algorithm created by the Caversham Project at the University of Otago. It implements the Caverphone 2.0
  * algorithm:
  *
- * @version $Id: Caverphone.java 1079535 2011-03-08 20:54:37Z ggregory $
  * @see <a href="http://en.wikipedia.org/wiki/Caverphone">Wikipedia - Caverphone</a>
  * @see <a href="http://caversham.otago.ac.nz/files/working/ctp150804.pdf">Caverphone 2.0 specification</a>
  * @since 1.4

--- a/src/main/java/org/apache/commons/codec/language/Caverphone1.java
+++ b/src/main/java/org/apache/commons/codec/language/Caverphone1.java
@@ -23,7 +23,6 @@ package org.apache.commons.codec.language;
  * This is an algorithm created by the Caversham Project at the University of Otago. It implements the Caverphone 1.0
  * algorithm:
  *
- * @version $Id: Caverphone.java 1075947 2011-03-01 17:56:14Z ggregory $
  * @see <a href="http://en.wikipedia.org/wiki/Caverphone">Wikipedia - Caverphone</a>
  * @see <a href="http://caversham.otago.ac.nz/files/working/ctp060902.pdf">Caverphone 1.0 specification</a>
  * @since 1.5

--- a/src/main/java/org/apache/commons/codec/language/Caverphone2.java
+++ b/src/main/java/org/apache/commons/codec/language/Caverphone2.java
@@ -23,7 +23,6 @@ package org.apache.commons.codec.language;
  * This is an algorithm created by the Caversham Project at the University of Otago. It implements the Caverphone 2.0
  * algorithm:
  *
- * @version $Id: Caverphone.java 1075947 2011-03-01 17:56:14Z ggregory $
  * @see <a href="http://en.wikipedia.org/wiki/Caverphone">Wikipedia - Caverphone</a>
  * @see <a href="http://caversham.otago.ac.nz/files/working/ctp150804.pdf">Caverphone 2.0 specification</a>
  * @since 1.5

--- a/src/main/java/org/apache/commons/codec/language/DaitchMokotoffSoundex.java
+++ b/src/main/java/org/apache/commons/codec/language/DaitchMokotoffSoundex.java
@@ -66,7 +66,6 @@ import org.apache.commons.codec.StringEncoder;
  * @see <a href="http://en.wikipedia.org/wiki/Daitch%E2%80%93Mokotoff_Soundex"> Wikipedia - Daitch-Mokotoff Soundex</a>
  * @see <a href="http://www.avotaynu.com/soundex.htm">Avotaynu - Soundexing and Genealogy</a>
  *
- * @version $Id$
  * @since 1.10
  */
 public class DaitchMokotoffSoundex implements StringEncoder {

--- a/src/main/java/org/apache/commons/codec/language/DoubleMetaphone.java
+++ b/src/main/java/org/apache/commons/codec/language/DoubleMetaphone.java
@@ -33,7 +33,6 @@ import org.apache.commons.codec.binary.StringUtils;
  * @see <a href="http://drdobbs.com/184401251?pgno=2">Original Article</a>
  * @see <a href="http://en.wikipedia.org/wiki/Metaphone">http://en.wikipedia.org/wiki/Metaphone</a>
  *
- * @version $Id$
  */
 public class DoubleMetaphone implements StringEncoder {
 

--- a/src/main/java/org/apache/commons/codec/language/Metaphone.java
+++ b/src/main/java/org/apache/commons/codec/language/Metaphone.java
@@ -48,7 +48,6 @@ import org.apache.commons.codec.StringEncoder;
  * is used to ensure safe publication of the value between threads, and must not invoke {@link #setMaxCodeLen(int)}
  * after initial setup.
  *
- * @version $Id$
  */
 public class Metaphone implements StringEncoder {
 

--- a/src/main/java/org/apache/commons/codec/language/Nysiis.java
+++ b/src/main/java/org/apache/commons/codec/language/Nysiis.java
@@ -65,7 +65,6 @@ import org.apache.commons.codec.StringEncoder;
  * @see <a href="http://www.dropby.com/NYSIIS.html">NYSIIS on dropby.com</a>
  * @see Soundex
  * @since 1.7
- * @version $Id$
  */
 public class Nysiis implements StringEncoder {
 

--- a/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java
+++ b/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java
@@ -27,7 +27,6 @@ import org.apache.commons.codec.StringEncoder;
  *
  * <p>This class is immutable and thread-safe.</p>
  *
- * @version $Id$
  */
 public class RefinedSoundex implements StringEncoder {
 

--- a/src/main/java/org/apache/commons/codec/language/Soundex.java
+++ b/src/main/java/org/apache/commons/codec/language/Soundex.java
@@ -27,7 +27,6 @@ import org.apache.commons.codec.StringEncoder;
  * This class is thread-safe.
  * Although not strictly immutable, the {@link #maxLength} field is not actually used.
  *
- * @version $Id$
  */
 public class Soundex implements StringEncoder {
 

--- a/src/main/java/org/apache/commons/codec/language/SoundexUtils.java
+++ b/src/main/java/org/apache/commons/codec/language/SoundexUtils.java
@@ -25,7 +25,6 @@ import org.apache.commons.codec.StringEncoder;
  *
  * <p>This class is immutable and thread-safe.</p>
  *
- * @version $Id$
  * @since 1.3
  */
 final class SoundexUtils {

--- a/src/main/java/org/apache/commons/codec/language/bm/BeiderMorseEncoder.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/BeiderMorseEncoder.java
@@ -74,7 +74,6 @@ import org.apache.commons.codec.StringEncoder;
  * This class is Not ThreadSafe
  * </p>
  * @since 1.6
- * @version $Id$
  */
 public class BeiderMorseEncoder implements StringEncoder {
     // Implementation note: This class is a spring-friendly facade to PhoneticEngine. It allows read/write configuration

--- a/src/main/java/org/apache/commons/codec/language/bm/Lang.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/Lang.java
@@ -67,7 +67,6 @@ import org.apache.commons.codec.Resources;
  * Port of lang.php
  *
  * @since 1.6
- * @version $Id$
  */
 public class Lang {
     // Implementation note: This class is divided into two sections. The first part is a static factory interface that

--- a/src/main/java/org/apache/commons/codec/language/bm/Languages.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/Languages.java
@@ -51,7 +51,6 @@ import org.apache.commons.codec.Resources;
  * This class is immutable and thread-safe.
  *
  * @since 1.6
- * @version $Id$
  */
 public class Languages {
     // Implementation note: This class is divided into two sections. The first part

--- a/src/main/java/org/apache/commons/codec/language/bm/NameType.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/NameType.java
@@ -23,7 +23,6 @@ package org.apache.commons.codec.language.bm;
  * specifically tuned to family names, and may not work well at all for general text.
  *
  * @since 1.6
- * @version $Id$
  */
 public enum NameType {
 

--- a/src/main/java/org/apache/commons/codec/language/bm/PhoneticEngine.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/PhoneticEngine.java
@@ -48,7 +48,6 @@ import org.apache.commons.codec.language.bm.Rule.Phoneme;
  * Ported from phoneticengine.php
  *
  * @since 1.6
- * @version $Id$
  */
 public class PhoneticEngine {
 

--- a/src/main/java/org/apache/commons/codec/language/bm/ResourceConstants.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/ResourceConstants.java
@@ -25,7 +25,6 @@ import org.apache.commons.codec.CharEncoding;
  * <p>This class is immutable and thread-safe.</p>
  *
  * @since 1.6
- * @version $Id$
  */
 class ResourceConstants {
 

--- a/src/main/java/org/apache/commons/codec/language/bm/Rule.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/Rule.java
@@ -77,7 +77,6 @@ import org.apache.commons.codec.language.bm.Languages.LanguageSet;
  * </ul>
  *
  * @since 1.6
- * @version $Id$
  */
 public class Rule {
 

--- a/src/main/java/org/apache/commons/codec/language/bm/RuleType.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/RuleType.java
@@ -21,7 +21,6 @@ package org.apache.commons.codec.language.bm;
  * Types of rule.
  *
  * @since 1.6
- * @version $Id$
  */
 public enum RuleType {
 

--- a/src/main/java/org/apache/commons/codec/net/BCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/BCodec.java
@@ -41,7 +41,6 @@ import org.apache.commons.codec.binary.Base64;
  *          Header Extensions for Non-ASCII Text</a>
  *
  * @since 1.3
- * @version $Id$
  */
 public class BCodec extends RFC1522Codec implements StringEncoder, StringDecoder {
     /**

--- a/src/main/java/org/apache/commons/codec/net/BCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/BCodec.java
@@ -179,7 +179,7 @@ public class BCodec extends RFC1522Codec implements StringEncoder, StringDecoder
         }
         try {
             return this.decodeText(value);
-        } catch (final UnsupportedEncodingException e) {
+        } catch (final UnsupportedEncodingException | IllegalArgumentException e) {
             throw new DecoderException(e.getMessage(), e);
         }
     }

--- a/src/main/java/org/apache/commons/codec/net/QCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/QCodec.java
@@ -47,7 +47,6 @@ import org.apache.commons.codec.StringEncoder;
  *          Header Extensions for Non-ASCII Text</a>
  *
  * @since 1.3
- * @version $Id$
  */
 public class QCodec extends RFC1522Codec implements StringEncoder, StringDecoder {
     /**

--- a/src/main/java/org/apache/commons/codec/net/QuotedPrintableCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/QuotedPrintableCodec.java
@@ -61,7 +61,6 @@ import org.apache.commons.codec.binary.StringUtils;
  *          Mechanisms for Specifying and Describing the Format of Internet Message Bodies </a>
  *
  * @since 1.3
- * @version $Id$
  */
 public class QuotedPrintableCodec implements BinaryEncoder, BinaryDecoder, StringEncoder, StringDecoder {
     /**

--- a/src/main/java/org/apache/commons/codec/net/RFC1522Codec.java
+++ b/src/main/java/org/apache/commons/codec/net/RFC1522Codec.java
@@ -37,7 +37,6 @@ import org.apache.commons.codec.binary.StringUtils;
  *          Message Header Extensions for Non-ASCII Text</a>
  *
  * @since 1.3
- * @version $Id$
  */
 abstract class RFC1522Codec {
 

--- a/src/main/java/org/apache/commons/codec/net/URLCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/URLCodec.java
@@ -43,7 +43,6 @@ import org.apache.commons.codec.binary.StringUtils;
  *           of the <a href="http://www.w3.org/TR/html4/">HTML 4.01 Specification</a>
  *
  * @since 1.2
- * @version $Id$
  */
 public class URLCodec implements BinaryEncoder, BinaryDecoder, StringEncoder, StringDecoder {
 

--- a/src/main/java/org/apache/commons/codec/net/Utils.java
+++ b/src/main/java/org/apache/commons/codec/net/Utils.java
@@ -24,7 +24,6 @@ import org.apache.commons.codec.DecoderException;
  *
  * <p>This class is immutable and thread-safe.</p>
  *
- * @version $Id$
  * @since 1.4
  */
 class Utils {

--- a/src/test/java/org/apache/commons/codec/BinaryEncoderAbstractTest.java
+++ b/src/test/java/org/apache/commons/codec/BinaryEncoderAbstractTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 /**
- * @version $Id$
  */
 public abstract class BinaryEncoderAbstractTest {
 

--- a/src/test/java/org/apache/commons/codec/CharEncodingTest.java
+++ b/src/test/java/org/apache/commons/codec/CharEncodingTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 /**
  * Sanity checks for {@link CharEncoding}.
  *
- * @version $Id$
  */
 public class CharEncodingTest {
 

--- a/src/test/java/org/apache/commons/codec/CharsetsTest.java
+++ b/src/test/java/org/apache/commons/codec/CharsetsTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 /**
  * Sanity checks for {@link Charsets}.
  *
- * @version $Id: CharEncodingTest.java 1298985 2012-03-09 19:12:49Z ggregory $
  */
 public class CharsetsTest {
 

--- a/src/test/java/org/apache/commons/codec/DecoderExceptionTest.java
+++ b/src/test/java/org/apache/commons/codec/DecoderExceptionTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 /**
  * Tests {@link DecoderException}.
  *
- * @version $Id$
  */
 public class DecoderExceptionTest {
 

--- a/src/test/java/org/apache/commons/codec/EncoderExceptionTest.java
+++ b/src/test/java/org/apache/commons/codec/EncoderExceptionTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 /**
  * Tests {@link EncoderException}.
  *
- * @version $Id$
  */
 public class EncoderExceptionTest {
 

--- a/src/test/java/org/apache/commons/codec/StringEncoderAbstractTest.java
+++ b/src/test/java/org/apache/commons/codec/StringEncoderAbstractTest.java
@@ -23,7 +23,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * @version $Id$
  */
 public abstract class StringEncoderAbstractTest<T extends StringEncoder> {
 

--- a/src/test/java/org/apache/commons/codec/StringEncoderComparatorTest.java
+++ b/src/test/java/org/apache/commons/codec/StringEncoderComparatorTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 /**
  * Test cases for the StingEncoderComparator.
  *
- * @version $Id$
  */
 public class StringEncoderComparatorTest {
 

--- a/src/test/java/org/apache/commons/codec/binary/Base32Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base32Test.java
@@ -46,7 +46,31 @@ public class Base32Test {
         {"foobar" ,"MZXW6YTBOI======"},
     };
 
-    private static final Object[][] BASE32_BINARY_TEST_CASES;
+	private static final String[] BASE32_IMPOSSIBLE_CASES = {
+		"MC======",
+		"MZXE====",
+		"MZXWB===",
+		"MZXW6YB=",
+		"MZXW6YTBOC======"
+	};
+
+	private static final String[] BASE32_IMPOSSIBLE_CASES_CHUNKED = {
+		"M2======\r\n",
+		"MZX0====\r\n",
+		"MZXW0===\r\n",
+		"MZXW6Y2=\r\n",
+		"MZXW6YTBO2======\r\n"
+	};
+
+	private static final String[] BASE32HEX_IMPOSSIBLE_CASES = {
+		"C2======",
+		"CPN4====",
+		"CPNM1===",
+		"CPNMUO1=",
+		"CPNMUOJ1E2======"
+	};
+
+        private static final Object[][] BASE32_BINARY_TEST_CASES;
 
     //            { null, "O0o0O0o0" }
 //            BASE32_BINARY_TEST_CASES[2][0] = new Hex().decode("739ce739ce");
@@ -248,4 +272,29 @@ public class Base32Test {
         }
     }
 
+    @Test
+    public void testBase32ImpossibleSamples() {
+        testImpossibleCases(new Base32(), BASE32_IMPOSSIBLE_CASES);
+    }
+
+    @Test
+    public void testBase32ImpossibleChunked() {
+        testImpossibleCases(new Base32(20), BASE32_IMPOSSIBLE_CASES_CHUNKED);
+    }
+
+    @Test
+    public void testBase32HexImpossibleSamples() {
+        testImpossibleCases(new Base32(true), BASE32HEX_IMPOSSIBLE_CASES);
+    }
+
+    private void testImpossibleCases(Base32 codec, String[] impossible_cases) {
+        for (String impossible : impossible_cases) {
+            try {
+                codec.decode(impossible);
+                fail();
+            } catch (IllegalArgumentException ex) {
+                // expected
+            }
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/codec/binary/Base32Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base32Test.java
@@ -46,31 +46,31 @@ public class Base32Test {
         {"foobar" ,"MZXW6YTBOI======"},
     };
 
-	private static final String[] BASE32_IMPOSSIBLE_CASES = {
-		"MC======",
-		"MZXE====",
-		"MZXWB===",
-		"MZXW6YB=",
-		"MZXW6YTBOC======"
-	};
+    private static final String[] BASE32_IMPOSSIBLE_CASES = {
+        "MC======",
+        "MZXE====",
+        "MZXWB===",
+        "MZXW6YB=",
+        "MZXW6YTBOC======"
+        };
 
-	private static final String[] BASE32_IMPOSSIBLE_CASES_CHUNKED = {
-		"M2======\r\n",
-		"MZX0====\r\n",
-		"MZXW0===\r\n",
-		"MZXW6Y2=\r\n",
-		"MZXW6YTBO2======\r\n"
-	};
+    private static final String[] BASE32_IMPOSSIBLE_CASES_CHUNKED = {
+        "M2======\r\n",
+        "MZX0====\r\n",
+        "MZXW0===\r\n",
+        "MZXW6Y2=\r\n",
+        "MZXW6YTBO2======\r\n"
+    };
 
-	private static final String[] BASE32HEX_IMPOSSIBLE_CASES = {
-		"C2======",
-		"CPN4====",
-		"CPNM1===",
-		"CPNMUO1=",
-		"CPNMUOJ1E2======"
-	};
+    private static final String[] BASE32HEX_IMPOSSIBLE_CASES = {
+        "C2======",
+        "CPN4====",
+        "CPNM1===",
+        "CPNMUO1=",
+        "CPNMUOJ1E2======"
+    };
 
-        private static final Object[][] BASE32_BINARY_TEST_CASES;
+    private static final Object[][] BASE32_BINARY_TEST_CASES;
 
     //            { null, "O0o0O0o0" }
 //            BASE32_BINARY_TEST_CASES[2][0] = new Hex().decode("739ce739ce");

--- a/src/test/java/org/apache/commons/codec/binary/Base32TestData.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base32TestData.java
@@ -26,7 +26,6 @@ import java.util.Random;
  * Commons-Codec and OpenSSL. Notice that OpenSSL creates 64 character lines instead of the 76 of Commons-Codec.
  *
  * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
- * @version $Id $
  * @since 1.4
  */
 public class Base32TestData {

--- a/src/test/java/org/apache/commons/codec/binary/Base64InputStreamTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64InputStreamTest.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import org.junit.Test;
 
 /**
- * @version $Id $
  * @since 1.4
  */
 public class Base64InputStreamTest {

--- a/src/test/java/org/apache/commons/codec/binary/Base64OutputStreamTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64OutputStreamTest.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import org.junit.Test;
 
 /**
- * @version $Id $
  * @since 1.4
  */
 public class Base64OutputStreamTest {

--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -39,7 +39,6 @@ import org.junit.Test;
  * Test cases for Base64 class.
  *
  * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
- * @version $Id$
  */
 public class Base64Test {
 

--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -45,6 +45,13 @@ public class Base64Test {
 
     private static final Charset CHARSET_UTF8 = Charsets.UTF_8;
 
+    private static final String[] BASE64_IMPOSSIBLE_CASES = {
+        "ZE==",
+        "ZmC=",
+        "Zm9vYE==",
+        "Zm9vYmC=",
+    };
+
     private final Random random = new Random();
 
     /**
@@ -1298,4 +1305,16 @@ public class Base64Test {
         assertEquals("testDEFAULT_BUFFER_SIZE", strOriginal, strDecoded);
     }
 
+    @Test
+    public void testBase64ImpossibleSamples() {
+        Base64 codec = new Base64();
+        for (String s : BASE64_IMPOSSIBLE_CASES) {
+            try {
+                codec.decode(s);
+                fail();
+            } catch (IllegalArgumentException ex) {
+                // expected
+            }
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/codec/binary/Base64TestData.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64TestData.java
@@ -26,7 +26,6 @@ import java.util.Random;
  * Commons-Codec and OpenSSL. Notice that OpenSSL creates 64 character lines instead of the 76 of Commons-Codec.
  *
  * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
- * @version $Id $
  * @since 1.4
  */
 public class Base64TestData {

--- a/src/test/java/org/apache/commons/codec/binary/Base64TestData.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64TestData.java
@@ -31,7 +31,7 @@ import java.util.Random;
  */
 public class Base64TestData {
 
-    public static final String CODEC_101_MULTIPLE_OF_3 = "123";
+    public static final String CODEC_101_MULTIPLE_OF_3 = "124";
 
     public static final String CODEC_98_NPE
         = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjAxMjM";

--- a/src/test/java/org/apache/commons/codec/binary/BinaryCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/BinaryCodecTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 /**
  * TestCase for BinaryCodec class.
  *
- * @version $Id$
  */
 public class BinaryCodecTest {
 

--- a/src/test/java/org/apache/commons/codec/binary/BinaryCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/BinaryCodecTest.java
@@ -38,31 +38,31 @@ public class BinaryCodecTest {
 
     private static final Charset CHARSET_UTF8 = Charsets.UTF_8;
 
-    /** mask with bit zero based index 0 raised */
+    /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_0 = 0x01;
 
-    /** mask with bit zero based index 0 raised */
+    /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_1 = 0x02;
 
-    /** mask with bit zero based index 0 raised */
+    /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_2 = 0x04;
 
-    /** mask with bit zero based index 0 raised */
+    /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_3 = 0x08;
 
-    /** mask with bit zero based index 0 raised */
+    /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_4 = 0x10;
 
-    /** mask with bit zero based index 0 raised */
+    /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_5 = 0x20;
 
-    /** mask with bit zero based index 0 raised */
+    /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_6 = 0x40;
 
-    /** mask with bit zero based index 0 raised */
+    /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_7 = 0x80;
 
-    /** an instance of the binary codec */
+    /** An instance of the binary codec. */
     BinaryCodec instance = null;
 
     @Before

--- a/src/test/java/org/apache/commons/codec/binary/BinaryCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/BinaryCodecTest.java
@@ -41,25 +41,25 @@ public class BinaryCodecTest {
     /** Mask with bit zero-based index 0 raised. */
     private static final int BIT_0 = 0x01;
 
-    /** Mask with bit zero-based index 0 raised. */
+    /** Mask with bit zero-based index 1 raised. */
     private static final int BIT_1 = 0x02;
 
-    /** Mask with bit zero-based index 0 raised. */
+    /** Mask with bit zero-based index 2 raised. */
     private static final int BIT_2 = 0x04;
 
-    /** Mask with bit zero-based index 0 raised. */
+    /** Mask with bit zero-based index 3 raised. */
     private static final int BIT_3 = 0x08;
 
-    /** Mask with bit zero-based index 0 raised. */
+    /** Mask with bit zero-based index 4 raised. */
     private static final int BIT_4 = 0x10;
 
-    /** Mask with bit zero-based index 0 raised. */
+    /** Mask with bit zero-based index 5 raised. */
     private static final int BIT_5 = 0x20;
 
-    /** Mask with bit zero-based index 0 raised. */
+    /** Mask with bit zero-based index 6 raised. */
     private static final int BIT_6 = 0x40;
 
-    /** Mask with bit zero-based index 0 raised. */
+    /** Mask with bit zero-based index 7 raised. */
     private static final int BIT_7 = 0x80;
 
     /** An instance of the binary codec. */

--- a/src/test/java/org/apache/commons/codec/binary/Codec105ErrorInputStream.java
+++ b/src/test/java/org/apache/commons/codec/binary/Codec105ErrorInputStream.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
  *
  * Recreates the bug described in CODEC-105.
  *
- * @version $Id $
  * @since 1.5
  */
 public class Codec105ErrorInputStream extends InputStream {

--- a/src/test/java/org/apache/commons/codec/binary/HexTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/HexTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 /**
  * Tests {@link org.apache.commons.codec.binary.Hex}.
  *
- * @version $Id$
  */
 public class HexTest {
 

--- a/src/test/java/org/apache/commons/codec/binary/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/StringUtilsTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 /**
  * Tests {@link StringUtils}
  *
- * @version $Id$
  */
 public class StringUtilsTest {
 

--- a/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
@@ -40,7 +40,6 @@ import org.junit.Test;
 /**
  * Tests DigestUtils methods.
  *
- * @version $Id$
  */
 public class DigestUtilsTest {
 

--- a/src/test/java/org/apache/commons/codec/digest/HmacUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/HmacUtilsTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 /**
  * Tests HmacUtils methods.
  *
- * @version $Id$
  */
 public class HmacUtilsTest {
 

--- a/src/test/java/org/apache/commons/codec/language/Caverphone1Test.java
+++ b/src/test/java/org/apache/commons/codec/language/Caverphone1Test.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 /**
  * Tests Caverphone1.
  *
- * @version $Id: CaverphoneTest.java 1075947 2011-03-01 17:56:14Z ggregory $
  * @since 1.5
  */
 public class Caverphone1Test extends StringEncoderAbstractTest<Caverphone1> {

--- a/src/test/java/org/apache/commons/codec/language/Caverphone2Test.java
+++ b/src/test/java/org/apache/commons/codec/language/Caverphone2Test.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 /**
  * Tests Caverphone2.
  *
- * @version $Id$
  * @since 1.5
  */
 public class Caverphone2Test extends StringEncoderAbstractTest<Caverphone2> {

--- a/src/test/java/org/apache/commons/codec/language/DoubleMetaphone2Test.java
+++ b/src/test/java/org/apache/commons/codec/language/DoubleMetaphone2Test.java
@@ -29,7 +29,6 @@ import org.junit.Test;
  * href="http://swoodbridge.com/DoubleMetaPhone/surnames.txt">PHP test program</a>.
  *
  * @see <a href="http://swoodbridge.com/DoubleMetaPhone/surnames.txt">PHP test program</a>
- * @version $Id$
  */
 public class DoubleMetaphone2Test extends StringEncoderAbstractTest<DoubleMetaphone> {
 

--- a/src/test/java/org/apache/commons/codec/language/DoubleMetaphoneTest.java
+++ b/src/test/java/org/apache/commons/codec/language/DoubleMetaphoneTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
  * <p>Keep this file in UTF-8 encoding for proper Javadoc processing.</p>
  *
  * @see "http://www.cuj.com/documents/s=8038/cuj0006philips/"
- * @version $Id$
  */
 public class DoubleMetaphoneTest extends StringEncoderAbstractTest<DoubleMetaphone> {
 

--- a/src/test/java/org/apache/commons/codec/language/MetaphoneTest.java
+++ b/src/test/java/org/apache/commons/codec/language/MetaphoneTest.java
@@ -25,7 +25,6 @@ import org.apache.commons.codec.StringEncoderAbstractTest;
 import org.junit.Test;
 
 /**
- * @version $Id$
  */
 public class MetaphoneTest extends StringEncoderAbstractTest<Metaphone> {
 

--- a/src/test/java/org/apache/commons/codec/language/NysiisTest.java
+++ b/src/test/java/org/apache/commons/codec/language/NysiisTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * Tests {@link Nysiis}
  *
  * @since 1.7
- * @version $Id$
  */
 public class NysiisTest extends StringEncoderAbstractTest<Nysiis> {
 

--- a/src/test/java/org/apache/commons/codec/language/RefinedSoundexTest.java
+++ b/src/test/java/org/apache/commons/codec/language/RefinedSoundexTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 /**
  * Tests RefinedSoundex.
  *
- * @version $Id$
  */
 public class RefinedSoundexTest extends StringEncoderAbstractTest<RefinedSoundex> {
 

--- a/src/test/java/org/apache/commons/codec/language/SoundexTest.java
+++ b/src/test/java/org/apache/commons/codec/language/SoundexTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
  *
  * <p>Keep this file in UTF-8 encoding for proper Javadoc processing.</p>
  *
- * @version $Id$
  */
 public class SoundexTest extends StringEncoderAbstractTest<Soundex> {
 

--- a/src/test/java/org/apache/commons/codec/net/BCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/BCodecTest.java
@@ -34,6 +34,12 @@ import org.junit.Test;
  * @version $Id$
  */
 public class BCodecTest {
+    private static final String[] BASE64_IMPOSSIBLE_CASES = {
+            "ZE==",
+            "ZmC=",
+            "Zm9vYE==",
+            "Zm9vYmC=",
+    };
 
     static final int SWISS_GERMAN_STUFF_UNICODE[] =
         { 0x47, 0x72, 0xFC, 0x65, 0x7A, 0x69, 0x5F, 0x7A, 0xE4, 0x6D, 0xE4 };
@@ -146,6 +152,19 @@ public class BCodecTest {
             fail("Trying to url encode a Double object should cause an exception.");
         } catch (final DecoderException ee) {
             // Exception expected, test segment passes.
+        }
+    }
+    
+    @Test
+    public void testBase64ImpossibleSamples() {
+        BCodec codec = new BCodec();
+        for (String s : BASE64_IMPOSSIBLE_CASES) {
+            try {
+                codec.decode(s);
+                fail();
+            } catch (DecoderException ex) {
+                // expected
+            }
         }
     }
 }

--- a/src/test/java/org/apache/commons/codec/net/BCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/BCodecTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 /**
  * Quoted-printable codec test cases
  *
- * @version $Id$
  */
 public class BCodecTest {
     private static final String[] BASE64_IMPOSSIBLE_CASES = {

--- a/src/test/java/org/apache/commons/codec/net/QCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/QCodecTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 /**
  * Quoted-printable codec test cases
  *
- * @version $Id$
  */
 public class QCodecTest {
 

--- a/src/test/java/org/apache/commons/codec/net/QuotedPrintableCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/QuotedPrintableCodecTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 /**
  * Quoted-printable codec test cases
  *
- * @version $Id$
  */
 public class QuotedPrintableCodecTest {
 

--- a/src/test/java/org/apache/commons/codec/net/RFC1522CodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/RFC1522CodecTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 /**
  * RFC 1522 compliant codec test cases
  *
- * @version $Id$
  */
 public class RFC1522CodecTest {
 

--- a/src/test/java/org/apache/commons/codec/net/URLCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/URLCodecTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 /**
  * URL codec test cases
  *
- * @version $Id$
  */
 public class URLCodecTest {
 

--- a/src/test/java/org/apache/commons/codec/net/UtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/net/UtilsTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
  * Methods currently get 100%/100% line/branch code coverage from other tests classes.
  * </p>
  *
- * @version $Id$
  * @since 1.4
  */
 public class UtilsTest {


### PR DESCRIPTION
To fix CODEC-134.